### PR TITLE
Fix latest editor's draft link

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,23 +34,23 @@
               companyURL: "https://agoric.com"}],
          license: "w3c-software-doc",
          processVersion: 2017,
-         edDraftURI: "https://w3c-ccg.github.io/zcap-ld/",
-         shortName: "zcap-ld",
+         edDraftURI: "https://w3c-ccg.github.io/zcap-spec/",
+         shortName: "zcap-spec",
          otherLinks: [
              {
                  "key": "Repository",
                  "data": [
                      {
                          "value": "Git repository",
-                         "href": "https://github.com/w3c-ccg/zcap-ld",
+                         "href": "https://github.com/w3c-ccg/zcap-spec",
                      },
                      {
                          "value": "Issues",
-                         "href": "https://github.com/w3c-ccg/zcap-ld/issues",
+                         "href": "https://github.com/w3c-ccg/zcap-spec/issues",
                      },
                      {
                          "value": "Commits",
-                         "href": "https://github.com/w3c-ccg/zcap-ld/commits/gh-pages",
+                         "href": "https://github.com/w3c-ccg/zcap-spec/commits/gh-pages",
                      }
                  ]
              }


### PR DESCRIPTION
This fixes the currently broken link to the latest ED and updates other links (accurately redirecting already).