### PR TITLE
Update terminology from previousCapability to parentCapability

### DIFF
--- a/index.html
+++ b/index.html
@@ -1125,8 +1125,8 @@ urn:uuid:<uuid>
         is used to both authorize further capability delegation and may be used
         to invoke the capability chain.
         The capability document that is invoked's chain is recursively traversed
-        up along the <code>previousCapability</code> document until the target is
-        found (the root document that has no <code>previousCapability</code>
+        up along the <code>parentCapability</code> document until the target is
+        found (the root document that has no <code>parentCapability</code>
         property).
         The target's <code>capabilityDelegation</code> cryptographic material is
         marked in the initial set of authority.


### PR DESCRIPTION
### Summary

This PR fixes a terminology inconsistency in the specification by replacing
`previousCapability` with `parentCapability` in the Invocation section.

As confirmed in Issue #52, the term “previous capability” / `previousCapability`
is a leftover from an earlier revision of the spec and should now be
standardized to “parent capability” / `parentCapability`.

### Changes

- Replaced all occurrences of `previousCapability` with `parentCapability`
  in the Invocation section.
- Updated surrounding text to ensure consistency with the terminology used
  throughout the Delegation and Capability Chain sections.
- Performed a light review to confirm no remaining references to the outdated term.

### Rationale

The rest of the specification consistently uses `parentCapability` to describe
capability delegation traversal. Using `previousCapability` in this section was
misleading and inconsistent. This PR aligns the terminology across the document.

### Related Issue

Fixes #52

### Notes

If there are additional sections that should be updated for consistency,
I’m happy to revise this PR accordingly.
