### PR TITLE
Add milestones informative appendix

### DIFF
--- a/index.html
+++ b/index.html
@@ -1375,9 +1375,25 @@ urn:uuid:<uuid>
         </p>
 
         <ol>
+
+            <li class="issue">
+                Fix this ReSpec warning:
+                <blockquote>
+                    Document uses RFC2119 keywords but lacks a conformance section.<br />
+                    How to fix: Please add a <code>&lt;section id="conformance"&gt;</code>.
+                </blockquote>
+
+                <p>Questions</p>
+                <ul>
+                    <li>Is adding a conformance section this a normative change?</li>
+                    <li>Is this appropriate for v0.4 milestone?</li>
+                </ul>
+            </li>
+
             <li class="issue">
                 v0.3 was published in 2022. Since then, some implementors have made changes to their implementations based on their experience in production, which may be incorporated into this spec. If this experience can be described, and the changes articulated, they may be incorporated into this document.
             </li>
+
         </ol>
     </section>
   </body>

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
          edDraftURI: "https://w3c-ccg.github.io/zcap-spec/",
          shortName: "zcap-spec",
          group: "credentials",
+         issueBase: "https://github.com/w3c-ccg/zcap-spec/issues/",
          otherLinks: [
              {
                  "key": "Repository",

--- a/index.html
+++ b/index.html
@@ -1359,19 +1359,9 @@ urn:uuid:<uuid>
         </section>
 
         <section>
-            <h3>v0.5: Use insights from production deployments</h3>
+            <h3>v0.5</h3>
             <p>
-                v0.3 was published in 2022. Since then, some implementors have made changes to their implementations based on their experience in production.
-                v0.4 may make minor normative changes based on this experience.
-            </p>
-            <ol>
-            </ol>
-        </section>
-
-        <section>
-            <h3>v0.6: TBD from backlog</h3>
-            <p>
-                Features may be added from the issue tracker or <a href="#backlog">backlog</a>.
+                This milestone is not yet planned. Once <a href="">v0.4</a> is done, it will be planned from issues in the <a href="#backlog">backlog</a> and issue tracker.
             </p>
         </section>
     </section>
@@ -1382,14 +1372,12 @@ urn:uuid:<uuid>
             These issues may be added to <a href="#milestones">milestones</a>.
             They may also be removed from the backlog.
             Generally, they are listed in priority order.
-            The backlog will be groomed after <a href="#milestone-v0.4">milestone v0.4</a>, based on community group review of the issue tracker, and in order to plan <a href="#milestone-v0.5">milestone v0.5</a>.
         </p>
 
         <ol>
-            <!-- Example
             <li class="issue">
+                v0.3 was published in 2022. Since then, some implementors have made changes to their implementations based on their experience in production, which may be incorporated into this spec. If this experience can be described, and the changes articulated, they may be incorporated into this document.
             </li>
-            -->
         </ol>
     </section>
   </body>

--- a/index.html
+++ b/index.html
@@ -1375,5 +1375,22 @@ urn:uuid:<uuid>
             </p>
         </section>
     </section>
+
+    <section class="appendix informative" id="backlog">
+        <h2>Backlog</h2>
+        <p>
+            These issues may be added to <a href="#milestones">milestones</a>.
+            They may also be removed from the backlog.
+            Generally, they are listed in priority order.
+            The backlog will be groomed after <a href="#milestone-v0.4">milestone v0.4</a>, based on community group review of the issue tracker, and in order to plan <a href="#milestone-v0.5">milestone v0.5</a>.
+        </p>
+
+        <ol>
+            <!-- Example
+            <li class="issue">
+            </li>
+            -->
+        </ol>
+    </section>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1341,5 +1341,39 @@ urn:uuid:<uuid>
         authentication material, and Alice revokes that capability.
       </p>
     </section>
+
+    <section class="appendix informative" id="milestones">
+        <h2>Milestones</h2>
+        <p>
+            This is a non-binding plan of how the authors intend this document to develop.
+        </p>
+
+        <section id="milestone-v0.4">
+            <h3>v0.4: Improve readability</h3>
+            <p>There will be no normative changes in v0.4.</p>
+            <ol>
+                <li class="issue" data-number="56">
+                    Remove TODOs expressed as spec text so the spec is more readable, and all issues are tracked in the issue tracker
+                </li>
+            </ol>
+        </section>
+
+        <section>
+            <h3>v0.5: Use insights from production deployments</h3>
+            <p>
+                v0.3 was published in 2022. Since then, some implementors have made changes to their implementations based on their experience in production.
+                v0.4 may make minor normative changes based on this experience.
+            </p>
+            <ol>
+            </ol>
+        </section>
+
+        <section>
+            <h3>v0.6: TBD from backlog</h3>
+            <p>
+                Features may be added from the issue tracker or <a href="#backlog">backlog</a>.
+            </p>
+        </section>
+    </section>
   </body>
 </html>


### PR DESCRIPTION
Motivation:
* advertise our intentions (as discussed in last CCG Storage TF call) in an appendix
* by doing this in the document, we have same review/approval process as other spec changes, and the plan lives in git not any one vendor's issue tracker
* milestones can still refer to issues in the issue tracker via respec https://github.com/speced/respec/wiki/issue
* adds https://github.com/w3c-ccg/zcap-spec/issues/56 to milestone