### PR TITLE
add minimal conformance section to resolve ReSpec warning about it missing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1203,6 +1203,15 @@ urn:uuid:<uuid>
       </section>
     </section>
 
+    <section id="conformance">
+        <!--
+        ReSpec will insert here something like:
+        > As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.
+        >
+        > The key words MAY, MUST, MUST NOT, and SHOULD in this document are to be interpreted as described in BCP 14 [RFC2119] [RFC8174] when, and only when, they appear in all capitals, as shown here.
+        -->
+    </section>
+
     <!-- TODO: explore whether composition is fully supported by the
          current state of this document
        -->


### PR DESCRIPTION
Motivation:
* resolve the ReSpec warning
* get to zero ReSpec warnings

I expect it may be improved later.

Questions
* Is this a normative change? I don't think so.