### PR TITLE
fix example 5 root zcap @context value to match normative requirements

### DIFF
--- a/index.html
+++ b/index.html
@@ -425,9 +425,7 @@
 
         <pre class="example highlight javascript">
 {
-  "@context": [
-    "https://w3id.org/zcap/v1"
-  ],
+  "@context": "https://w3id.org/zcap/v1",
   "id": "urn:zcap:root:https%3A%2F%2Fexample.com%2Ffoo",
   "controller": "did:key:example",
   "invocationTarget": "https://example.com/foo"


### PR DESCRIPTION
Motivation:
* https://github.com/w3c-ccg/zcap-spec/issues/47