### PR TITLE
change version in title from v0.3 to v0.4.0-draft

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset='utf-8'>
-    <title>Authorization Capabilities for Linked Data v0.3</title>
+    <title>Authorization Capabilities for Linked Data v0.4.0-draft</title>
     <script src='//www.w3.org/Tools/respec/respec-w3c' class='remove'></script>    <script class='remove'>
      var respecConfig = {
          specStatus: "CG-DRAFT",


### PR DESCRIPTION
Motivation:
* adopt a standard version number format (semver.org) with affordances for distinguishing final releases from pre-release versions
* bump title to pre release version of v0.4, so it's clear in the editor's draft we are not changing v0.3, but working on a draft of v0.4. I chose 'draft' as the semver pre-release name because it corresponds to the "editor's draft" colloquialism used in CCG and other W3C groups
