### PR TITLE
editorial cleanup of inline 'TODO:', '[link]', and '[Note:...]'

### DIFF
--- a/index.html
+++ b/index.html
@@ -505,8 +505,8 @@ urn:zcap:root:${encodeURIComponent(invocationTarget)}
           root zcap. The controller (or controllers) may take any actions with
           the invocation target (that are supported by the verifier) by
           invoking the root zcap. The controller (or controllers) may create
-          delegated zcaps from the root zcap [TODO: link to delegated zcap
-          section].
+          <a href="#delegated-capability">delegated zcaps</a>
+          from the root zcap.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -835,13 +835,6 @@ urn:uuid:<uuid>
             the full delegated zcap.
           </p>
 
-         
-
-          <p>
-            TODO: Detail algorithm for validation process:
-            https://github.com/digitalbazaar/zcapld/blob/4386185f784f552d6eaeb2c3c82959cb2e09762e/lib/CapabilityProofPurpose.js#L85
-          </p>
-
           <p>
             TODO: Detail how revocation works: Any controller in the chain of a
             delegated zcap may post that zcap to:
@@ -1373,9 +1366,7 @@ urn:uuid:<uuid>
             Generally, they are listed in priority order.
         </p>
 
-        <ol>
-
-            <li class="issue">
+            <div class="issue">
                 Fix this ReSpec warning:
                 <blockquote>
                     Document uses RFC2119 keywords but lacks a conformance section.<br />
@@ -1387,13 +1378,22 @@ urn:uuid:<uuid>
                     <li>Is adding a conformance section this a normative change?</li>
                     <li>Is this appropriate for v0.4 milestone?</li>
                 </ul>
-            </li>
+            </div>
 
-            <li class="issue">
+            <div class="issue">
                 v0.3 was published in 2022. Since then, some implementors have made changes to their implementations based on their experience in production, which may be incorporated into this spec. If this experience can be described, and the changes articulated, they may be incorporated into this document.
-            </li>
+            </div>
 
-            <li class="issue"
+            <div class="issue"
+                title="Detail validation algorithm"
+              >
+              <p>
+                Detail algorithm for validation process:
+                https://github.com/digitalbazaar/zcapld/blob/4386185f784f552d6eaeb2c3c82959cb2e09762e/lib/CapabilityProofPurpose.js#L85
+              </p>              
+            </div>
+
+            <div class="issue"
                 title="Add Revocation Section"
             >
               <p>
@@ -1425,9 +1425,8 @@ urn:uuid:<uuid>
                   .
                 </li>
               </ul>
-            </li>
+            </div>
 
-        </ol>
     </section>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -707,7 +707,7 @@ urn:uuid:<uuid>
           invocation target attenuation <!-- TODO: link --> is permitted, that it has the
           `invocationTarget` from the parent capability as a prefix. A prefix is
           defined as a base URI and parent path (and optional query) (i.e.,
-          `/`-delimited and `?`/`&`-delimited) [more rigorous definition].
+          `/`-delimited and `?`/`&`-delimited) <!-- TODO: more rigorous definition -->
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -704,7 +704,7 @@ urn:uuid:<uuid>
           expresses a URI. The invocation target identifies where the zcap may
           be invoked. A verifier MUST ensure that the `invocationTarget` either
           matches the `invocationTarget` in the parent capability or, if
-          invocation target attenuation [link] is permitted, that it has the
+          invocation target attenuation <!-- TODO: link --> is permitted, that it has the
           `invocationTarget` from the parent capability as a prefix. A prefix is
           defined as a base URI and parent path (and optional query) (i.e.,
           `/`-delimited and `?`/`&`-delimited) [more rigorous definition].

--- a/index.html
+++ b/index.html
@@ -695,8 +695,8 @@ urn:uuid:<uuid>
         <p>
           A verifier MUST limit the length of the capability chain to prevent
           long chain attacks. A verifier SHOULD limit the length of the
-          capability chain to 10. [exposition on why 10 / link to security
-          section].
+          capability chain to 10. <!-- exposition on why 10 / link to security
+          section]. -->
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -466,7 +466,7 @@
           Additionally, JSON-LD compatibility enables CBOR-LD to be used
           to express zcaps &mdash; further reducing size via semantic compression.
 
-          [Note: [See invoking a root zcap section]. When invoking a root zcap,
+          When <a href="#invoking-root-capability">invoking a root zcap</a>,
           a capability invocation proof is added, not to the root zcap itself,
           but rather to another document that is acceptable to an API. This
           means that no additional contexts (especially cryptosuite contexts) ever

--- a/index.html
+++ b/index.html
@@ -835,15 +835,6 @@ urn:uuid:<uuid>
             the full delegated zcap.
           </p>
 
-          <p>
-            TODO: Detail how revocation works: Any controller in the chain of a
-            delegated zcap may post that zcap to:
-            `<rootInvocationTarget>/zcaps/revocations/<zcapToRevokeId>` using the
-              root zcap: `urn:zcap:root:encodeURIComponent(<rootInvocationTarget>/zcaps/revocations/<zcapToRevokeId>)`
-                to revoke.
-                Example: https://github.com/digitalbazaar/ezcap-express/blob/main/lib/revoke.js
-          </p>
-
         </section>
       </section>
     </section>
@@ -1416,6 +1407,15 @@ urn:uuid:<uuid>
                     invoked. The verifier SHOULD set the controllers for that root
                     zcap to all controllers in the (to be revoked) zcap's chain so
                     that any controller in the chain can revoke the zcap.
+                </li>
+                <li>
+                  Any controller in the chain of a
+                  delegated zcap may post that zcap to:
+                  `{rootInvocationTarget}/zcaps/revocations/{zcapToRevokeId}`
+                  using the
+                  root zcap: `urn:zcap:root:encodeURIComponent("{rootInvocationTarget}/zcaps/revocations/{zcapToRevokeId}")`
+                  to revoke.
+                  Example: https://github.com/digitalbazaar/ezcap-express/blob/main/lib/revoke.js
                 </li>
                 <li>
                   Link to example server-side revocation implementations like

--- a/index.html
+++ b/index.html
@@ -646,8 +646,7 @@ urn:zcap:root:${encodeURIComponent(invocationTarget)}
           A delegated zcap MUST have an `@context` field with an array where the
           first value is the zcapld context and any subsequent values identify
           context(s) used to define vocabulary terms used in the capability
-          delegation proof. [Note: Maximum array size should be defined in the
-          spec along with rationale].
+          delegation proof.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -714,7 +714,7 @@ urn:uuid:<uuid>
           A delegated zcap MUST have a `controller` that is a string or an array
           of strings that each express a URI that identifies a controller for
           the delegated zcap. The controller (or controllers) may take any
-          allowed actions [link] with the invocation target (that are supported
+          allowed <a href="#actions">actions</a> with the invocation target (that are supported
           by the verifier) by invoking the delegated zcap. The controller (or
           controllers) may create delegated zcaps from the delegated zcap.
           <i><b>Note:</b> As with other data model sections in W3C specs, every property

--- a/index.html
+++ b/index.html
@@ -775,7 +775,7 @@ urn:uuid:<uuid>
           A delegated zcap MUST have a `proof` field that is an object or an
           array of objects that each express a DI proof. At least one of these
           proofs MUST be a zcap capability delegation proof.
-          [TODO: more details on this proof]
+          <!-- TODO: more details on this proof -->
         </p>
 
         <p>
@@ -1369,6 +1369,23 @@ urn:uuid:<uuid>
                     <li>Is adding a conformance section this a normative change?</li>
                     <li>Is this appropriate for v0.4 milestone?</li>
                 </ul>
+            </div>
+
+            <div
+              class="issue"
+              title="Clarify Delegation Proof"
+              >
+              <p>
+                Add more details to the requirements on delegation proof property.
+
+                Consider linking to
+                <a href="https://www.w3.org/TR/vc-data-integrity-1.1/">
+                  vc-data-integrity-1.1
+                </a>.
+              </p>
+              <blockquote>
+                A delegated zcap MUST have a proof field that is an object or an array of objects that each express a DI proof. At least one of these proofs MUST be a zcap capability delegation proof.
+              </blockquote>
             </div>
 
             <div class="issue">

--- a/index.html
+++ b/index.html
@@ -835,17 +835,7 @@ urn:uuid:<uuid>
             the full delegated zcap.
           </p>
 
-          <p>
-            TODO: Add section on revocation, detailing what verifiers MUST/SHOULD
-            do to provide revocation endpoints for zcaps. A root invocation
-            target SHOULD have a `/zcaps/revocations` subpath, where a root zcap of
-            `urn:zcap:root:<the revocations path/the zcap ID to revoke>` can be
-              invoked. The verifier SHOULD set the controllers for that root
-              zcap to all controllers in the (to be revoked) zcap's chain so
-              that any controller in the chain can revoke the zcap. Link to
-              example server-side revocation implementation:
-              https://github.com/digitalbazaar/ezcap-express/blob/main/lib/revoke.js
-          </p>
+         
 
           <p>
             TODO: Detail algorithm for validation process:
@@ -1401,6 +1391,40 @@ urn:uuid:<uuid>
 
             <li class="issue">
                 v0.3 was published in 2022. Since then, some implementors have made changes to their implementations based on their experience in production, which may be incorporated into this spec. If this experience can be described, and the changes articulated, they may be incorporated into this document.
+            </li>
+
+            <li class="issue"
+                title="Add Revocation Section"
+            >
+              <p>
+                Explain revocation behavior in a new section.
+              </p>
+              <p>
+                Wishlist
+              </p>
+              <ul>
+                <li>
+                  Add a named section for other sections to link to for an overview of revocation.
+                </li>
+                <li>
+                  Detail what verifiers MUST/SHOULD do to provide revocation endpoints for zcaps.
+                </li>
+                <li>
+                  A root invocation
+                  target SHOULD have a `/zcaps/revocations` subpath, where a root zcap of
+                  `urn:zcap:root:<the revocations path/the zcap ID to revoke>` can be
+                    invoked. The verifier SHOULD set the controllers for that root
+                    zcap to all controllers in the (to be revoked) zcap's chain so
+                    that any controller in the chain can revoke the zcap.
+                </li>
+                <li>
+                  Link to example server-side revocation implementations like
+                  <a href="https://github.com/digitalbazaar/ezcap-express/blob/main/lib/revoke.js">
+                    digitalbazaar's ezcap-express
+                  </a>
+                  .
+                </li>
+              </ul>
             </li>
 
         </ol>

--- a/index.html
+++ b/index.html
@@ -479,8 +479,8 @@
           A root zcap MUST have an `id` that is a string that expresses a URN.
           This ID can always be dereferenced by the verifier system if it is a
           valid root zcap for a particular endpoint. The ID of a root zcap
-          SHOULD [Note: this should become a MUST if it covers all use cases,
-          to keep things simple] have the following format:
+          SHOULD <!-- this should become a MUST if it covers all use cases,
+          to keep things simple --> have the following format:
         </p>
 
         <pre>

--- a/index.html
+++ b/index.html
@@ -741,9 +741,11 @@ urn:uuid:<uuid>
 
         <p>
           A verifier SHOULD ensure that an invoked delegated zcap does not have
-          an expiration date-time that is more than three months in the
-          future. [TODO: exposition on why 3 months?] This is because a verifier
-          MUST store revoked zcaps [link to revocation] until they expire, to
+          an expiration date-time that is more than three months in the future.
+          <!-- TODO: explain why 3 months -->
+          This is because a verifier
+          MUST store revoked zcaps until they expire, to
+          <!-- TODO: add revocation section and link to it -->
           prevent their use. A delegated zcap with an expiration date that is
           unreasonably far into the future will have to be stored for an
           unreasonable period of time to prevent its invocation. There are

--- a/index.html
+++ b/index.html
@@ -580,7 +580,7 @@ urn:zcap:root:${encodeURIComponent(invocationTarget)}
           </p>
 
           <pre class="example highlight javascript">
-            {
+{
   "@context": [
     "https://w3id.org/zcap/v1"
   ],


### PR DESCRIPTION
Motivation:
* making it easier for readers to read the specified behaviors without the meta commentary, which can be linked to in appropriate appendix, e.g. Backlog
* progress #56 
* fix slightly broken example 6 syntax
* change backlog markup to no longer use `<ol />` to fix bug with how respec renders `li.issue`

Goals
* this PR should make no changes that would be considered normative changes
* stick to editorial cleanup appropriate for 0.4.0

Notes:
* I was able to handle some of these note directly, e.g. replacing `[link]` with an appropriate html link
* for notes that are too discretionary to document in backlog, I converted some to HTML comments so the reader is spared from them.

