### PR TITLE
fix Example 2 capabilityInvocation proof does not express the full invoked capability

### DIFF
--- a/index.html
+++ b/index.html
@@ -1415,6 +1415,11 @@ urn:uuid:<uuid>
             </li>
 
         </ol>
+
+        <section
+          data-include="issue/20260807-embed-example2-proof-capability.md"
+          data-include-format="markdown"
+          ></section>
     </section>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -254,7 +254,26 @@
         // proofPurpose of capabilityInvocation and links to the capability
         // chain it is invoking
         "proofPurpose": "capabilityInvocation",
-        "capability": "https://whatacar.example/a-fancy-car/proc/7a397d7b",
+        "capability": {
+          "@context": "https://w3id.org/zcap/v1",
+          "id": "urn:uuid:d2c83c43-878a-4c01-984f-b2f57932ce5f",
+          "parentCapability": "urn:uuid:f7412b9a-854b-47ab-806b-3ac736cc7cda",
+          "controller": "did:key:dummy",
+          "expires": "2026-01-31T00:00:00Z",
+          "allowedAction": [
+            "https://example.com/storage/method/UploadFile"
+          ],
+          "proof": [
+            {
+              "type": "DataIntegrityProof",
+              "cryptosuite": "eddsa-jcs-2022",
+              "created": "2026-01-01T00:00:00Z",
+              "verificationMethod": "did:key:bob#bob",
+              "proofPurpose": "capabilityDelegation",
+              "proofValue": "zQeVbY4oey5q2M3XKaxup3tmzN4DRFTLVqpLMweBrSxMY2xHX5XTYV8nQApmEcqaqA3Q1gVHMrXFkXJeV6doDwLWx"
+            }
+          ]
+        },
         "created": "2016-02-08T17:13:48Z",
         "creator": "https://social.example/alyssa/#key-for-car",
         "signatureValue": "..."}}

--- a/issue/20260807-embed-example2-proof-capability.md
+++ b/issue/20260807-embed-example2-proof-capability.md
@@ -1,0 +1,62 @@
+# Issue: Example 2 capabilityInvocation proof does not express the full invoked capability
+
+Example 2 is like
+```json
+{"@context": ["https://w3id.org/zcap/v1",
+              "https://autopower.example/"],
+ "id": "urn:uuid:ad86cb2c-e9db-434a-beae-71b82120a8a4",
+ "action": "Drive",
+ "proof": {
+    "type": "RsaSignature2016",
+    // A linked data document can be an invocation if it has a
+    // proofPurpose of capabilityInvocation and links to the capability
+    // chain it is invoking
+    "proofPurpose": "capabilityInvocation",
+    "capability": "https://whatacar.example/a-fancy-car/proc/7a397d7b",
+    "created": "2016-02-08T17:13:48Z",
+    "creator": "https://social.example/alyssa/#key-for-car",
+    "signatureValue": "..."}}
+```
+
+The `proof.capability` value is a string HTTPS URL `https://whatacar.example/a-fancy-car/proc/7a397d7b`, which seems to represent invoking the delegated capability from example 1.
+
+However, later the spec requires
+> When invoking a delegated capability using a DI proof, the capability property must express the full delegated zcap.
+
+Example 2 appears not to satisfy this requirement, because the invocation proof's capability property identifies the delegated zcap it is invoking, but does not "express the full delegated zcap".
+
+## Proposal: Example 2 `proof.capability` should be full capability
+
+Change Example 2's to have a new `proof.capability` value identical to Example 1 (which is invoked by Example 2), so the new Example 2 matches:
+```json
+{"@context": ["https://w3id.org/zcap/v1",
+              "https://autopower.example/"],
+ "id": "urn:uuid:ad86cb2c-e9db-434a-beae-71b82120a8a4",
+ "action": "Drive",
+ "proof": {
+    "type": "RsaSignature2016",
+    "proofPurpose": "capabilityInvocation",
+    "capability": {
+        "@context": ["https://w3id.org/zcap/v1",
+                    "https://autopower.example/"],
+        "id": "https://whatacar.example/a-fancy-car/proc/7a397d7b",
+        "parentCapability": "https://whatacar.example/a-fancy-car",
+        "controller": "https://social.example/alyssa#key-for-car",
+        "proof": {
+            "type": "Ed25519Signature2018",
+            "created": "2018-02-13T21:26:08Z",
+            "capabilityChain": [
+            "https://whatacar.example/a-fancy-car"
+            ],
+            "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..lfAFjrWE-4RxhL0gtzSMRX72NR9SRDgaMmkjPA4if0ERbw4R2bnts5sAs8OyhAlbFzBAKOqrFk57AYqwSR2vCw",
+            "proofPurpose": "capabilityDelegation",
+            "verificationMethod": "https://example.com/i/alice/keys/1"
+        }
+    },
+    "created": "2016-02-08T17:13:48Z",
+    "creator": "https://social.example/alyssa/#key-for-car",
+    "signatureValue": "..."}}
+```
+
+By changing the invocation DI proof's `capability` property to be the full expression of the invoked delegated capability, this now satisfies the requirement
+> When invoking a delegated capability using a DI proof, the capability property must express the full delegated zcap.

--- a/issue/20260807-embed-example2-proof-capability.md
+++ b/issue/20260807-embed-example2-proof-capability.md
@@ -60,3 +60,9 @@ Change Example 2's to have a new `proof.capability` value identical to Example 1
 
 By changing the invocation DI proof's `capability` property to be the full expression of the invoked delegated capability, this now satisfies the requirement
 > When invoking a delegated capability using a DI proof, the capability property must express the full delegated zcap.
+
+## Resolution
+
+This issue was resolved by accepting the proposal above,
+and replacing example 2 `proof.capability` with the full expression of the invoked capability delegation so the following requirement is satisfied
+> When invoking a delegated capability using a DI proof, the capability property must express the full delegated zcap.


### PR DESCRIPTION
Motivation:
* get consensus that the [issue](https://github.com/w3c-ccg/zcap-spec/pull/77/changes#diff-a7802fe290048dd7c2c03f7480dcc455e8bcae23cf3e564ad8e06e1e14de03de) describes a legitimate concern of the current zcap-spec example 2. it appears to not satisfy the existing requirements of Invocations using DI Proofs.
* discuss my proposal to fix
