### PR TITLE
fix ambiguous grammar in Capabilities section note "understands for what the meaning of those arguments are and for what they may be used"

### DIFF
--- a/index.html
+++ b/index.html
@@ -977,7 +977,7 @@ urn:uuid:<uuid>
           that it know for what specific purpose it has been granted that
           capability so that it does not become confused and use it in the
           wrong scenario.
-          This is not unlike how in computer programs a procedure called with
+          This is like how, in computer programs, a procedure called with
           specific arguments understands the meanings of those arguments
           and what they may be used for.
         </p>

--- a/index.html
+++ b/index.html
@@ -978,8 +978,8 @@ urn:uuid:<uuid>
           capability so that it does not become confused and use it in the
           wrong scenario.
           This is not unlike how in computer programs a procedure called with
-          specific arguments understands for what the meaning of those arguments
-          are and for what they may be used.
+          specific arguments understands the meanings of those arguments
+          and what they may be used for.
         </p>
       </div>
 


### PR DESCRIPTION
Motivation:
* When I read the text before this change, I had to double-take to understand it. I think primarily because of the subject-verb ambiguity in "for what the meaning of those arguments are. This change simplifies the sentence by avoiding the multiple "for what"s and dropping the double negative 'not unlike'. The result is a simpler and clearer sentence, and less ambiguity