### PR TITLE
replace examples' usage of RsaSignature2016 with DataIntegrityProof so examples exemplify a much more common proof type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,7 @@ Non-normative
 
 * Fix respec warning "Document uses RFC2119 keywords but lacks a conformance section." by adding a minimal conformance section.
   * Pull Request: <https://github.com/w3c-ccg/zcap-spec/pull/59>
+
+* Replaced all usage of RsaSignature2016 in examples with [DataIntegrityProof](https://www.w3.org/TR/vc-data-integrity/#dataintegrityproof),
+  which use the property named proofValue (instead of the formerly used signatureValue) for the output of the algorithm used by the verification method.
+  This makes the examples a better reflection of the kind of proofs described by the rest of the spec.

--- a/index.html
+++ b/index.html
@@ -249,15 +249,16 @@
      "id": "urn:uuid:ad86cb2c-e9db-434a-beae-71b82120a8a4",
      "action": "Drive",
      "proof": {
-        "type": "RsaSignature2016",
+        "type": "DataIntegrityProof",
+        "cryptosuite": "eddsa-jcs-2022",
         // A linked data document can be an invocation if it has a
         // proofPurpose of capabilityInvocation and links to the capability
         // chain it is invoking
         "proofPurpose": "capabilityInvocation",
         "capability": "https://whatacar.example/a-fancy-car/proc/7a397d7b",
         "created": "2016-02-08T17:13:48Z",
-        "creator": "https://social.example/alyssa/#key-for-car",
-        "signatureValue": "..."}}
+        "verificationMethod": "https://social.example/alyssa/#key-for-car",
+        "proofValue": "..."}}
         </pre>
 
         <p>
@@ -303,11 +304,12 @@
      // Finally Alyssa signs this object with the key she was granted
      // authority with
      "proof": {
-        "type": "RsaSignature2016",
+        "type": "DataIntegrityProof",
+        "cryptosuite": "eddsa-jcs-2022",
         "proofPurpose": "capabilityDelegation",
         "created": "2017-03-28T06:01:25Z",
-        "creator": "https://social.example/alyssa/#key-for-car",
-        "signatureValue": "...",
+        "verificationMethod": "https://social.example/alyssa/#key-for-car",
+        "proofValue": "...",
         "capabilityChain": [
           "urn:zcap:root:https%3A%2F%2Fwhatacar.example%2Fa-fancy-car",
           // This should be the full expression of the parentCapability (i.e. Example 1)
@@ -378,11 +380,12 @@
      // Finally Ben signs this object with the key he was granted
      // authority with
      "proof": {
-        "type": "RsaSignature2016",
+        "type": "DataIntegrityProof",
+        "cryptosuite": "eddsa-jcs-2022",
         "proofPurpose": "capabilityDelegation",
         "created": "2017-06-13T19:15:03Z",
-        "creator": "https://chatty.example/ben/#key-33",
-        "signatureValue": "...",
+        "verificationMethod": "https://chatty.example/ben/#key-33",
+        "proofValue": "...",
         "capabilityChain": [
           "urn:zcap:root:https%3A%2F%2Fwhatacar.example%2Fa-fancy-car",
           "https://whatacar.example/a-fancy-car/proc/7a397d7b",
@@ -398,11 +401,12 @@
                "uri": "https://social.example/alyssa/ben-can-still-drive"}
             ],
             "proof": {
-              "type": "RsaSignature2016",
+              "type": "DataIntegrityProof",
+              "cryptosuite": "eddsa-jcs-2022",
               "proofPurpose": "capabilityDelegation",
               "created": "2017-03-28T06:01:25Z",
-              "creator": "https://social.example/alyssa/#key-for-car",
-              "signatureValue": "...",
+              "verificationMethod": "https://social.example/alyssa/#key-for-car",
+              "proofValue": "...",
               "capabilityChain": [
                 "urn:zcap:root:https%3A%2F%2Fwhatacar.example%2Fa-fancy-car",
                 // This is the full expression of the parentCapability (i.e. Example 1)

--- a/index.html
+++ b/index.html
@@ -1459,6 +1459,11 @@ urn:uuid:{uuid}
                 Before, the example text identified the parent capability using an HTTPS URL.
                 After, example 1 conforms to the requirement that delegations identify root capabilities using a URN.
               </li>
+              <li>
+                Removed all usage in examples of zcap proofs that use type RsaSignature2016.
+                Replace with proofs of type <a href="https://www.w3.org/TR/vc-data-integrity/#dataintegrityproof">DataIntegrityProof</a>,
+                which use the property named proofValue (instead of the formerly used signatureValue) for the output of cryptosuite.
+              </li>
             </ul>
 
             <p>Plan for v0.4.x</p>


### PR DESCRIPTION
Many zcap-spec examples show a `proof.type` value of `RsaSignature2016`, but that proof type is more a decade old, never made progress on a standards track, doesn't seem to have much real-world adoption, and exemplifies conventions that are different than what a reader should expect in the wild today.

In a review of #78, @kezike noted it's surprising that examples use `signatureValue` (part of `RsaSignature2016`), so I created https://github.com/w3c-ccg/zcap-spec/issues/85

This PR makes first improvement based on that issue by completely removing use of `signatureValue` property in examples, by switching the examples to no longer use proof type `RsaSignature2016` and instead use `DataIntegrityProof` type that has `proofValue` property.

This only changes examples, so is considered a non-normative change.


