### PR TITLE
GitHub Pages can host prerelease/past versions of spec by deploying to `/{version}/` not just `/`

### DIFF
--- a/.github/scripts/gh-pages-index.sh
+++ b/.github/scripts/gh-pages-index.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Regenerate the root index.html of the gh-pages site.
+#
+#   $ .github/scripts/gh-pages-index.sh ./gh-pages
+#
+# Lists every `v*` directory found at the root of the given directory, and
+# redirects to the latest non-pull-request version when loaded. Append `?all`
+# to the URL to see the listing without being redirected.
+set -euo pipefail
+
+root="${1:?usage: gh-pages-index.sh <gh-pages-dir>}"
+
+if [ ! -d "$root" ]; then
+  echo "gh-pages-index: no such directory: $root" >&2
+  exit 1
+fi
+
+# Collect version directories (portable: no mapfile, no find -printf).
+
+# Sort versions by semver precedence, ascending, on stdin/stdout.
+# `sort -V` alone is wrong here: it ranks `v0.4.0-draft` above `v0.4.0`, but
+# semver says a prerelease precedes its release. Split each version into
+# core + prerelease, give a missing prerelease the sentinel `~` (which sorts
+# after all alphanumerics in the C locale), then sort core with -V.
+semver_sort() {
+  sed '/^$/d' \
+    | awk '{
+        core = $0; pre = "~";
+        i = index($0, "-");
+        if (i > 0) { core = substr($0, 1, i - 1); pre = substr($0, i + 1); }
+        # Zero-pad numeric prerelease identifiers so pr.7 sorts before pr.52.
+        n = split(pre, part, ".");
+        key = "";
+        for (j = 1; j <= n; j++) {
+          key = key (part[j] ~ /^[0-9]+$/ ? sprintf("%010d", part[j]) : part[j]) ".";
+        }
+        printf "%s\t%s\t%s\n", core, key, $0;
+      }' \
+    | LC_ALL=C sort -t "$(printf '\t')" -k1,1V -k2,2 \
+    | cut -f3
+}
+
+versions=""
+for dir in "$root"/v[0-9]*/; do
+  [ -d "$dir" ] || continue
+  name="$(basename "$dir")"
+  versions="${versions}${name}
+"
+done
+versions="$(printf '%s' "$versions" | semver_sort || true)"
+
+if [ -z "$versions" ]; then
+  echo "gh-pages-index: no version directories found in $root" >&2
+fi
+
+# Releases vs. pull-request previews. A PR preview looks like `v0.4.0-pr.52`.
+releases="$(printf '%s\n' "$versions" | grep -v -E -- '-pr\.[0-9]+' || true)"
+previews="$(printf '%s\n' "$versions" | grep    -E -- '-pr\.[0-9]+' || true)"
+
+# "latest" never points at a pull-request preview, so an open PR can never
+# hijack the root redirect.
+latest="$(printf '%s\n' "$releases" | semver_sort | tail -n 1 || true)"
+
+html_escape() {
+  printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g'
+}
+
+list_items() {
+  # $1: newline separated version names, newest first
+  local name
+  printf '%s\n' "$1" | semver_sort | tac | while IFS= read -r name; do
+    local esc
+    esc="$(html_escape "$name")"
+    printf '        <li><a href="./%s/">%s</a></li>\n' "$esc" "$esc"
+  done
+}
+
+{
+  cat <<'HTML_HEAD'
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Authorization Capabilities (ZCAP) — published versions</title>
+<style>
+  :root { color-scheme: light dark; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    line-height: 1.5;
+    max-width: 42rem;
+    margin: 0 auto;
+    padding: 2rem 1.25rem 4rem;
+  }
+  h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+  h2 { font-size: 1rem; text-transform: uppercase; letter-spacing: 0.04em; opacity: 0.7; margin-top: 2rem; }
+  p.lede { margin-top: 0; opacity: 0.8; }
+  ul { list-style: none; padding: 0; }
+  li { padding: 0.4rem 0; border-bottom: 1px solid rgba(128,128,128,0.25); }
+  a { text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  footer { margin-top: 3rem; font-size: 0.85rem; opacity: 0.65; }
+  code { font-size: 0.9em; }
+</style>
+</head>
+<body>
+<h1>Authorization Capabilities (ZCAP)</h1>
+<p class="lede">Published versions of the specification.</p>
+HTML_HEAD
+
+  if [ -n "$(printf '%s' "$releases" | sed '/^$/d')" ]; then
+    printf '\n<h2>Versions</h2>\n<ul>\n'
+    list_items "$releases"
+    printf '</ul>\n'
+  fi
+
+  if [ -n "$(printf '%s' "$previews" | sed '/^$/d')" ]; then
+    printf '\n<h2>Pull request previews</h2>\n<ul>\n'
+    list_items "$previews"
+    printf '</ul>\n'
+  fi
+
+  if [ -n "$latest" ]; then
+    printf '\n<footer>Loading this page redirects to <a href="./%s/">%s</a>. Append <code>?all</code> to stay here.</footer>\n' \
+      "$(html_escape "$latest")" "$(html_escape "$latest")"
+  fi
+
+  cat <<HTML_SCRIPT
+
+<script>
+(function () {
+  var latest = "$(html_escape "$latest")";
+  if (!latest) { return; }
+  // Escape hatch: /?all or /#all shows this listing instead of redirecting.
+  if (/(^|[?&#])all(=|&|\$)/.test(window.location.search + window.location.hash)) { return; }
+  window.location.replace(latest + "/" + window.location.hash);
+})();
+</script>
+HTML_SCRIPT
+
+  cat <<'HTML_TAIL'
+</body>
+</html>
+HTML_TAIL
+} > "$root/index.html"
+
+# gh-pages should serve files verbatim, not run them through Jekyll.
+touch "$root/.nojekyll"
+
+echo "gh-pages-index: wrote $root/index.html (latest=${latest:-none})"

--- a/.github/scripts/spec-version.sh
+++ b/.github/scripts/spec-version.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Print the spec version parsed out of the <title> element of an HTML file.
+#
+#   $ .github/scripts/spec-version.sh index.html
+#   v0.4.0-draft
+#
+# The <title> is the single source of truth for the version of the spec,
+# e.g. `<title>Authorization Capabilities v0.4.0-draft</title>`.
+set -euo pipefail
+
+html="${1:-index.html}"
+
+if [ ! -f "$html" ]; then
+  echo "spec-version: no such file: $html" >&2
+  exit 1
+fi
+
+# Join lines so a <title> split across lines still matches, then take the
+# first non-greedy <title>...</title>.
+title="$(tr '\n' ' ' < "$html" | grep -o -i -E '<title>[^<]*</title>' | head -n 1 || true)"
+
+if [ -z "$title" ]; then
+  echo "spec-version: no <title> element found in $html" >&2
+  exit 1
+fi
+
+# semver, optionally with a `-prerelease` and/or `+build` part.
+version="$(printf '%s' "$title" \
+  | grep -o -E 'v?[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?' \
+  | head -n 1 || true)"
+
+if [ -z "$version" ]; then
+  echo "spec-version: no semver found in title: $title" >&2
+  exit 1
+fi
+
+case "$version" in
+  v*) ;;
+  *) version="v$version" ;;
+esac
+
+printf '%s\n' "$version"

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,160 @@
+# Publish the spec to the `gh-pages` branch under a version prefix.
+#
+# The version comes from the <title> element of index.html, e.g.
+# it might publish to
+# `gh-pages:/v0.4.0-draft/` and is served at
+# <https://OWNER.github.io/zcap-spec/v0.4.0-draft/>.
+#
+# The root index.html of gh-pages is regenerated on every deploy: it lists all
+# published versions and redirects to the latest non-pull-request one.
+name: Deploy to gh-pages
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version prefix (default: parsed from <title> in index.html)"
+        required: false
+        type: string
+      update_root_index:
+        description: "Regenerate the gh-pages root index.html"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+# Serialize deploys: concurrent runs would race on pushing gh-pages. With
+# cancel-in-progress false, rapid pushes to main queue instead of racing, and
+# GitHub drops superseded pending runs -- fine here, since each run republishes
+# the whole prefix from its own checkout and the last one wins.
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          path: src
+
+      - name: Determine version prefix
+        id: version
+        working-directory: src
+        env:
+          # Passed through the environment, never interpolated into the shell,
+          # so workflow inputs cannot inject commands.
+          INPUT_VERSION: ${{ inputs.version }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${INPUT_VERSION:-}" ]; then
+            version="$INPUT_VERSION"
+          else
+            version="$(.github/scripts/spec-version.sh index.html)"
+          fi
+
+          case "$version" in
+            v*) ;;
+            *) version="v$version" ;;
+          esac
+
+          # For a pull request build, add `-pr.N` to prerelease part
+          # so `v0.4.0-draft` on PR 52 becomes `v0.4.0-pr.52`.
+          if [ -n "${PR_NUMBER:-}" ] && [ -z "${INPUT_VERSION:-}" ]; then
+            versionNoBuild="${versionNoBuild%%+*}"
+            version="${versionNoBuild}-pr.${PR_NUMBER}"
+          fi
+
+          # Reject anything that is not a plain semver -- this string becomes a
+          # directory name and is passed to `rm -rf`.
+          if ! printf '%s' "$version" | grep -q -E '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+            echo "::error::refusing to deploy to unsafe version prefix: $version"
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Publishing to prefix: $version"
+
+      - name: Check out gh-pages branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          if git ls-remote --exit-code --heads "$remote" gh-pages >/dev/null 2>&1; then
+            git clone --depth 1 --branch gh-pages "$remote" gh-pages
+          else
+            echo "gh-pages branch does not exist yet; creating it"
+            mkdir gh-pages
+            git -C gh-pages init --quiet
+            git -C gh-pages checkout --quiet -b gh-pages
+            git -C gh-pages remote add origin "$remote"
+          fi
+
+      - name: Copy spec into version prefix
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          # Replace the prefix wholesale so removed files do not linger.
+          rm -rf "gh-pages/${VERSION}"
+          mkdir -p "gh-pages/${VERSION}"
+
+          # `git archive HEAD` is exactly the tracked files, with no .git dir
+          # and no untracked build junk.
+          git -C src archive HEAD | tar -x -C "gh-pages/${VERSION}"
+
+          # CI config is not part of the published spec.
+          rm -rf "gh-pages/${VERSION}/.github"
+
+          ls -la "gh-pages/${VERSION}"
+
+      - name: Regenerate root index
+        # Always regenerate, except when a manual run explicitly opts out.
+        # Do NOT write this as `inputs.update_root_index != false`: on a push
+        # event `inputs.update_root_index` is null, and GitHub casts both null
+        # and false to 0, so that comparison is false and the step is skipped.
+        if: github.event_name != 'workflow_dispatch' || inputs.update_root_index
+        run: src/.github/scripts/gh-pages-index.sh gh-pages
+
+      - name: Commit and push
+        working-directory: gh-pages
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to publish."
+            exit 0
+          fi
+
+          git commit -m "deploy ${VERSION} from ${GITHUB_SHA}"
+          git push origin HEAD:gh-pages
+
+      - name: Summary
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          owner="${GITHUB_REPOSITORY%%/*}"
+          repo="${GITHUB_REPOSITORY##*/}"
+          url="https://${owner}.github.io/${repo}/${VERSION}/"
+          {
+            echo "### Deployed \`${VERSION}\`"
+            echo ""
+            echo "<${url}>"
+            echo ""
+            echo "If this is the first deploy, enable GitHub Pages for this repository"
+            echo "with source \`Deploy from a branch\` → \`gh-pages\` / \`/ (root)\`."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that deploys the zcap-spec to `/{version}/` where `{version}` is parsed out of the title of `index.html`.

Before this change, one GitHub repo's GitHub Pages could only show the spec from one branch on that repo.
Now the GitHub Pages can show the spec from many branches on that repo, because each branch can be deployed to a subdirectory in gh-pages.

It supports deploying to `/index.html` a version index that will immediately redirect to the latest version. 

This does not add any triggers except `workflow_dispatch`. i.e. merging this will not lead to the action running on every push or pull request. It will allow us to trigger it manually, which will limit risk while being good enough for CODEOWNERS to use to deploy release candidates at URLs like `/v0.4.0-rc/`. We can always improve it later.

Proof of concept: https://gobengo.github.io/zcap-spec/v0.4.0-draft/