### PR TITLE
add invocation examples and new sections for Invocation HTTP Request and Invocation JSON

### DIFF
--- a/index.html
+++ b/index.html
@@ -606,10 +606,10 @@ urn:zcap:root:${encodeURIComponent(invocationTarget)}
           </p>
           <ul>
             <li>
-              by <a href="#proving-invocation-with-http-signature">using an HTTP signature</a> in an HTTP request
+              <a href="#invocation-http-request">Invocation HTTP requests</a>, i.e. attaching `capability-invocation` and `signature` headers to an http request
             </li>
             <li>
-              by <a href="#proving-invocation-with-data-integrity-proof">attaching an LD capability invocation proof to a document</a>
+              <a href="#invocation-json-proof">Invocation JSON objects</a>, i.e. attaching a `capabilityInvocation` proof to a object's `proof` set
             </li>
           </ul>
 
@@ -1196,51 +1196,145 @@ urn:uuid:{uuid}
         </p>
       </div>
 
-      <section id="proving-invocation-with-http-signature">
-        <h2>Proving Invocation with HTTP Signature</h2>
+  <section id="invocation-http-request">
+        <h2>Invocation HTTP Request</h2>
+        <section id="invocation-http-signature">
+          <h3>Invocation HTTP Signature</h3>
 
-        <p>
-          When invoking a root zcap using an HTTP signature, a
-          capability-invocation header must be included that identifies the
-          root zcap by ID (via an `id` parameter) and the capability action
-          that is being invoked (via an `action` parameter). The request URL
-          identifies the intended invocation target, which must either match
-          the invocation target in the root zcap, or, if the verifier allows
-          it, have the root zcap's invocation target as a prefix. The
-          capability action must be an action that is expected (supported) by
-          the verifier at the request URL. The capability action SHOULD be
-          read or write. The key used to create the HTTP signature must be either
-          1) the private key paired with a verification method that matches
-          the controller of the root zcap or 2) a verification method that is
-          controlled by the controller of the root zcap &mdash; and authorized for the
-          purpose of `capabilityInvocation`.
-        </p>
+          <p>
+            When invoking a root zcap using an HTTP signature, a
+            capability-invocation header must be included that identifies the
+            root zcap by ID (via an `id` parameter) and the capability action
+            that is being invoked (via an `action` parameter). The request URL
+            identifies the intended invocation target, which must either match
+            the invocation target in the root zcap, or, if the verifier allows
+            it, have the root zcap's invocation target as a prefix. The
+            capability action must be an action that is expected (supported) by
+            the verifier at the request URL. The capability action SHOULD be
+            read or write. The key used to create the HTTP signature must be either
+            1) the private key paired with a verification method that matches
+            the controller of the root zcap or 2) a verification method that is
+            controlled by the controller of the root zcap &mdash; and authorized for the
+            purpose of `capabilityInvocation`.
+          </p>
 
-        <p>
-          When invoking a delegated zcap using an HTTP signature, a
-          capability-invocation header must be included that includes the full
-          delegated zcap in a `capability` parameter by serializing it to JSON,
-          gzipping the result, and then base64url-encoding the gzipped JSON.
-        </p>
+          <p>
+            When invoking a delegated zcap using an HTTP signature, a
+            capability-invocation header must be included that includes the full
+            delegated zcap in a `capability` parameter by serializing it to JSON,
+            gzipping the result, and then base64url-encoding the gzipped JSON.
+          </p>
+
+        </section>
+
+        <section id="invocation-http-example">
+          <h4>Example Invocation HTTP Requests</h4>
+
+          <figure id="fig-invocation-http-example-basic">
+            <figcaption>
+              This is an example of how a capability invocation request may be serialized as message/http.
+            </figcaption>
+            <pre class="example http" title="Invocation HTTP Request">
+POST /api/v1/example HTTP/1.1
+Host: example.com
+Date: Tue, 25 Aug 2026 00:00:00 GMT
+Content-Type: application/json
+Capability-Invocation: zcap capability={base64url(gzip(json(capability)))}
+Content-Digest: sha-256=:y6p4T1s616oH+n04bZ9NzPzqB2qR+B/T3V7V9XN6b4Y=:
+Signature-Input: zcap=("@method" "@path" "capability-invocation" "content-digest" "content-type");alg="ed25519";created=1798294620;keyid="did:example:alice#key-1"
+Signature: zcap=:m28+dfHk1Pq6VvKxFxX9Q9zNz98bX5cKldP1M0zNzM3NzUzNzdXNzr1PzM3NzUzNzUzNzr1PzM3NzUzNzUzNzM3NzA==:
+
+{"type":"ExampleApiAction"}
+
+            </pre>
+          </figure>
+
+          <figure id="fig-invocation-http-example-with-trailers">
+            <figcaption>
+              This is an example of how a capability invocation request may be serialized as message/http using trailing headers.
+              This enables deferral of generating a digest and signature until after all data has been transmitted.
+            </figcaption>
+            <pre class="example http" title="Invocation HTTP Request with Trailing Headers">
+POST /api/v1/example HTTP/1.1
+Host: example.com
+Date: Tue, 25 Aug 2026 00:00:00 GMT
+Content-Type: application/json
+TE: trailers
+Trailer: Capability-Invocation, Content-Digest, Signature-Input, Signature
+Transfer-Encoding: chunked
+
+1B
+{"type":"ExampleApiAction"}
+0
+Capability-Invocation: zcap capability={base64url(gzip(json(capability)))}
+Content-Digest: sha-256=:y6p4T1s616oH+n04bZ9NzPzqB2qR+B/T3V7V9XN6b4Y=:
+Signature-Input: zcap=("@method" "@path" "capability-invocation" "content-digest" "content-type");alg="ed25519";created=1798294620;keyid="did:example:alice#key-1"
+Signature: zcap=:m28+dfHk1Pq6VvKxFxX9Q9zNz98bX5cKldP1M0zNzM3NzUzNzdXNzr1PzM3NzUzNzUzNzr1PzM3NzUzNzUzNzM3NzA==:
+
+            </pre>
+          </figure>
+        </section>
+
+
       </section>
 
-      <section id="proving-invocation-with-data-integrity-proof">
-        <h2>Proving Invocation with Data Integrity Proof</h2>
+      <section id="invocation-json">
+        <h2>Invocation JSON</h2>
 
         <p>
-          When invoking using a DI proof, a capability invocation proof must
-          be attached to a document that is acceptable by the API, as
-          defined by the specific API being accessed. The capability
-          invocation proof MUST include the intended `invocationTarget`, the
-          root zcap ID in the `capability` property, and the action to be taken
-          in the `capabilityAction` property. The same controller rules apply
-          as in <a href="#proving-invocation-with-http-signature">the HTTP signature case</a>.
+          HTTP isn't always the best choice for representing invocations.
+          Some peers may wish to wish to represent the invocation proofs in pure JSON instead of HTTP Signatures,
+          e.g. because they intend to request invocation over a protocol other than HTTP.
+          For this, there is a standard representation of zcap invocations as JSON objects.
         </p>
 
-        <p>
-          When invoking a delegated capability using a DI proof,
-          the capability property must express the full delegated zcap.
-        </p>
+        <section id="invocation-json-proof">
+          <h3>Invocation JSON `proof`</h3>
+
+          <p>
+            When invoking using a DI proof, a capability invocation proof must
+            be attached to a document that is acceptable by the API, as
+            defined by the specific API being accessed. The capability
+            invocation proof MUST include the intended `invocationTarget`, the
+            root zcap ID in the `capability` property, and the action to be taken
+            in the `capabilityAction` property. The same controller rules apply
+            as in <a href="#invocation-http-signature">the HTTP signature case</a>.
+          </p>
+
+          <p>
+            When invoking a delegated capability using a DI proof,
+            the capability property must express the full delegated zcap.
+          </p>
+
+
+          <figure id="invocation-json-example">
+            <figcaption>
+              An example of how a capability invocation may be serialized as application/json.
+            </figcaption>
+            <pre
+              class="example json"
+              title="Capability Invocation JSON"
+              >
+{
+  "id": "urn:uuid:394a2467-bd2e-4d39-9e42-d1881737f82e",
+  "proof": {
+    "type": "DataIntegrityProof",
+    "proofPurpose": "capabilityInvocation",
+    "cryptosuite": "eddsa-jcs-2022",
+    "capability": "https://whatacar.example/a-fancy-car/proc/7a397d7b",
+    "created": "2016-02-08T17:13:48Z",
+    "verificationMethod": "https://social.example/alyssa/#key-for-car",
+    "proofValue": "..."
+  },
+  "@context": [
+    "https://w3id.org/zcap/v1",
+    "https://autopower.example/"
+  ]
+}
+            </pre>
+          </figure>
+
+        </section>
       </section>
 
       <section id="actions">
@@ -1464,6 +1558,24 @@ urn:uuid:{uuid}
                 Replace with proofs of type <a href="https://www.w3.org/TR/vc-data-integrity/#dataintegrityproof">DataIntegrityProof</a>,
                 which use the property named proofValue (instead of the formerly used signatureValue) for the output of cryptosuite.
               </li>
+
+              <li>
+                Added <a href="#invocation-http-request">Invocation HTTP Request</a>.
+                This establishes a clearly-named section in the Table of Contents offering accesses a reference description of how an invocation may be represented as an HTTP Request.
+              </li>
+
+              <li>
+                Added <a href="#invocation-json">Invocation JSON</a> and <a href="#invocation-http-request">Invocation HTTP Request</a>,
+                This establishes a clearly-named section in the Table of Contents offering accesses for reference description of how an invocation may be represented as JSON.
+              </li>
+
+              <li>
+                Added <a href="#invocation-http-example">Example Invocation HTTP Requests</a> and
+                <a href="#invocation-json-example">Example Invocation JSON</a>.
+                Previously, there were no examples of how an invocation is expressed as an HTTP request.
+                The new example illustrates the general form of the invocation request much more quickly and clearly than the previous text-only description.
+              </li>              
+
             </ul>
 
             <p>Plan for v0.4.x</p>


### PR DESCRIPTION
## Why?

* good to have examples in message/http that illustrate how
* section titles are more minimal this way and establish good section ids for internal links

See the changes in the changelog for more details.

## What?

### Old

<img width="415" height="135" alt="Screenshot 2026-08-25 at 7 48 05 PM" src="https://github.com/user-attachments/assets/073dd7d6-dd8d-40d6-a385-78005e4e05e2" />

### New

<img width="378" height="209" alt="Screenshot 2026-08-25 at 7 49 32 PM" src="https://github.com/user-attachments/assets/207e7d02-d09a-4ae9-9a68-f2551342c321" />

## Goals

* no normative changes intended. editorial only so this could be in v0.4.0