### PR TITLE
add backlog items for specifying proof/verification algorithms

### DIFF
--- a/index.html
+++ b/index.html
@@ -1715,85 +1715,164 @@ Signature: zcap=:m28+dfHk1Pq6VvKxFxX9Q9zNz98bX5cKldP1M0zNzM3NzUzNzdXNzr1PzM3NzUz
     </section>
 
     <section class="appendix informative" id="backlog">
-        <h2>Backlog</h2>
-        <p>
-            These issues may be added to <a href="#milestones">milestones</a>.
-            They may also be removed from the backlog.
-            Generally, they are listed in priority order.
-        </p>
+      <h2>Backlog</h2>
+      <p>
+          These issues may be added to <a href="#milestones">milestones</a>.
+          They may also be removed from the backlog.
+          Generally, they are listed in priority order.
+      </p>
 
-            <div
-              class="issue"
-              title="Clarify Delegation Proof"
-              >
-              <p>
-                Add more details to the requirements on delegation proof property.
+      <section>
+        <h3>
+          Clarify delegated capability `proof` property
+        </h3>
 
-                Consider linking to
-                <a href="https://www.w3.org/TR/vc-data-integrity-1.1/">
-                  vc-data-integrity-1.1
-                </a>.
-              </p>
+        <p>Acceptance Criteria:</p>
+        <ul>
+          <li>
+            <div>
+              Answer questions about these requirements
               <blockquote>
-                A delegated zcap MUST have a proof field that is an object or an array of objects that each express a DI proof. At least one of these proofs MUST be a zcap capability delegation proof.
+                A delegated zcap MUST have a proof field that is an object or an array of objects that each express a DI proof.
+                At least one of these proofs MUST be a zcap capability delegation proof.
               </blockquote>
             </div>
+            <ul>
+              <li>What is meant by "each express a DI proof"? Clarify or remove that clause.</li>
+              <li>Are non-DataIntegrityProof values allowed?</li>
+              <li>What is meant by "MUST be a zcap capability delegation proof"?</li>
+            </ul>
+          </li>
+          <li>
+            Add a normative reference to
+            <a href="https://www.w3.org/TR/vc-data-integrity-1.1/">
+              vc-data-integrity-1.1
+            </a>.
+          </li>
+        </ul>
+      </section>
 
-            <div class="issue">
-                v0.3 was published in 2022. Since then, some implementors have made changes to their implementations based on their experience in production, which may be incorporated into this spec. If this experience can be described, and the changes articulated, they may be incorporated into this document.
-            </div>
+      <section>
+        <h3>Specify algorithms for delegation proof</h3>
+        <p>Acceptance Criteria:</p>
+        <ul>
+          <li>
+            Specify an algorithm to add a `capabilityDelegation` proof to a delegated capability.
+            This should be similar to
+            <a href="https://www.w3.org/TR/vc-data-integrity/#add-proof">
+              Add Proof in VC Data Integrity.
+            </a>
+          </li>
+          <li>
+            Specify an algorithm to verify a `capabilityDelegation` proof on a delegated capability.
+            This should be similar to
+            <a href="https://www.w3.org/TR/vc-data-integrity/#verify-proof">
+              Verify Proof in VC Data Integrity
+            </a>
+            (but for zcap delegations).
+          </li>
+        </ul>
+      </section>
 
-            <div class="issue"
-                title="Detail validation algorithm"
-              >
-              <p>
-                Detail algorithm for validation process:
-                https://github.com/digitalbazaar/zcapld/blob/4386185f784f552d6eaeb2c3c82959cb2e09762e/lib/CapabilityProofPurpose.js#L85
-              </p>              
-            </div>
+      <section>
+        <h3>Specify algorithms for invocation HTTP proof</h3>
+        <p>Acceptance Criteria:</p>
+        <ul>
+          <li>
+            Specify algorithm to create an Invocation HTTP Request from a delegated capability.
+          </li>
+          <li>
+            Specify an algorithm to add a proof of invocation to a
+            <a href="#invocation-http-request">invocation HTTP request</a>.
+            This should be similar to
+            <a href="https://www.w3.org/TR/vc-data-integrity/#add-proof">
+              Add Proof in VC Data Integrity.
+            </a>
+          </li>
+        </ul>
+      </section>
 
-            <div class="issue"
-                title="Add Revocation Section"
-            >
-              <p>
-                Explain revocation behavior in a new section.
-              </p>
-              <p>
-                Wishlist
-              </p>
-              <ul>
-                <li>
-                  Add a named section for other sections to link to for an overview of revocation.
-                </li>
-                <li>
-                  Detail what verifiers MUST/SHOULD do to provide revocation endpoints for zcaps.
-                </li>
-                <li>
-                  A root invocation
-                  target SHOULD have a `/zcaps/revocations` subpath, where a root zcap of
-                  `urn:zcap:root:{the revocations path/the zcap ID to revoke}` can be
-                    invoked. The verifier SHOULD set the controllers for that root
-                    zcap to all controllers in the (to be revoked) zcap's chain so
-                    that any controller in the chain can revoke the zcap.
-                </li>
-                <li>
-                  Any controller in the chain of a
-                  delegated zcap may post that zcap to:
-                  `{rootInvocationTarget}/zcaps/revocations/{zcapToRevokeId}`
-                  using the
-                  root zcap: `urn:zcap:root:encodeURIComponent("{rootInvocationTarget}/zcaps/revocations/{zcapToRevokeId}")`
-                  to revoke.
-                  Example: https://github.com/digitalbazaar/ezcap-express/blob/main/lib/revoke.js
-                </li>
-                <li>
-                  Link to example server-side revocation implementations like
-                  <a href="https://github.com/digitalbazaar/ezcap-express/blob/main/lib/revoke.js">
-                    digitalbazaar's ezcap-express
-                  </a>
-                  .
-                </li>
-              </ul>
-            </div>
+      <section>
+        <h3>Specify algorithms for invocation JSON proof</h3>
+        <p>Acceptance Criteria:</p>
+        <ul>
+          <li>
+            Specify an algorithm to add a `capabilityInvocation` proof to
+            <a href="#invocation-json">invocation JSON</a>.
+            This should be similar to
+            <a href="https://www.w3.org/TR/vc-data-integrity/#add-proof">
+              Add Proof in VC Data Integrity.
+            </a>
+          </li>
+          <li>
+            Specify an algorithm to verify a `capabilityInvocation` proof on an invocation JSON.
+            <a href="#invocation-json">invocation JSON</a>.
+            This should be similar to
+            <a href="https://www.w3.org/TR/vc-data-integrity/#verify-proof">
+              Verify Proof in VC Data Integrity.
+            </a>
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h3>Other Issues</h3>
+
+        <div class="issue">
+            v0.3 was published in 2022. Since then, some implementors have made changes to their implementations based on their experience in production, which may be incorporated into this spec. If this experience can be described, and the changes articulated, they may be incorporated into this document.
+        </div>
+
+        <div class="issue"
+            title="Detail validation algorithm"
+          >
+          <p>
+            Detail algorithm for validation process:
+            https://github.com/digitalbazaar/zcapld/blob/4386185f784f552d6eaeb2c3c82959cb2e09762e/lib/CapabilityProofPurpose.js#L85
+          </p>              
+        </div>
+
+        <div class="issue"
+            title="Add Revocation Section"
+        >
+          <p>
+            Explain revocation behavior in a new section.
+          </p>
+          <p>
+            Wishlist
+          </p>
+          <ul>
+            <li>
+              Add a named section for other sections to link to for an overview of revocation.
+            </li>
+            <li>
+              Detail what verifiers MUST/SHOULD do to provide revocation endpoints for zcaps.
+            </li>
+            <li>
+              A root invocation
+              target SHOULD have a `/zcaps/revocations` subpath, where a root zcap of
+              `urn:zcap:root:{the revocations path/the zcap ID to revoke}` can be
+                invoked. The verifier SHOULD set the controllers for that root
+                zcap to all controllers in the (to be revoked) zcap's chain so
+                that any controller in the chain can revoke the zcap.
+            </li>
+            <li>
+              Any controller in the chain of a
+              delegated zcap may post that zcap to:
+              `{rootInvocationTarget}/zcaps/revocations/{zcapToRevokeId}`
+              using the
+              root zcap: `urn:zcap:root:encodeURIComponent("{rootInvocationTarget}/zcaps/revocations/{zcapToRevokeId}")`
+              to revoke.
+              Example: https://github.com/digitalbazaar/ezcap-express/blob/main/lib/revoke.js
+            </li>
+            <li>
+              Link to example server-side revocation implementations like
+              <a href="https://github.com/digitalbazaar/ezcap-express/blob/main/lib/revoke.js">
+                digitalbazaar's ezcap-express
+              </a>
+              .
+            </li>
+          </ul>
+        </div>
 
         <div
           class="issue"
@@ -1809,6 +1888,7 @@ Signature: zcap=:m28+dfHk1Pq6VvKxFxX9Q9zNz98bX5cKldP1M0zNzM3NzUzNzdXNzr1PzM3NzUz
             For example, the plugin could collapse or minimize some values unless the end-user clicks to expand and show a fuller example that takes up more space.
           </p>
         </div>
+      </section>
     </section>
   </body>
 </html>


### PR DESCRIPTION
Motivation:
* elaborate on these issues in the backlog so they are understandable and we can discuss (later) whether we should schedule them into a milestone
* use section elements with headings for these issues, so the titles of the issues appear in the table of contents, giving an overview of the backlog from the respec TOC, and allowing for permalinks
  * previously the issues used respec `<div class="issue">...`, but with that markup, the issues don't appear in the TOC, and it's not as easy to get a permalink to a backlog issue. This PR leaves some lower priority issues with this markup but in an "Other Issues" subsection of the backlog