### PR TITLE
remove 'The capability action SHOULD be read or write.'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ This change log records changes that have been made since earlier versions of th
 Planned changes are described in [Milestones](index.html#milestones)
 Unscheduled possible changes are documented in [Backlog](index.html#backlog) until they are understood enough to schedule into Milestones.
 
+<h2 id="changelog-v0.5.0">v0.5.0</h2>
+
+Unlike [v0.4.0](#changelog-v0.4.0), this release may include normative changes.
+
+<h3 id="changelog-v0.5.0-normative">Normative</h3>
+
+* Removed the recommendation "The capability action SHOULD be read or write." from
+  [Invocation HTTP Signature](index.html#invocation-http-signature).
+  The document never defined `read` or `write`, so the recommendation was not actionable,
+  and it contradicted [Actions](index.html#actions),
+  which says targets are free to choose their own action vocabulary
+  and illustrates this with `https://datastore.example/WriteFile`.
+  It is common for an invocation to invoke a domain-specific action other than these two.
+  What remains is the requirement that already governed the capability action:
+  it must be an action that the verifier expects at the request URL.
+  * No previously-conforming invocation becomes non-conforming:
+    the recommendation discouraged other actions, but never prohibited them.
+
 <h2 id="changelog-v0.4.0">v0.4.0</h2>
 
 The goals of this release are

--- a/index.html
+++ b/index.html
@@ -1271,8 +1271,7 @@ urn:uuid:{uuid}
             the invocation target in the root zcap, or, if the verifier allows
             it, have the root zcap's invocation target as a prefix. The
             capability action must be an action that is expected (supported) by
-            the verifier at the request URL. The capability action SHOULD be
-            read or write. The key used to create the HTTP signature must be either
+            the verifier at the request URL. The key used to create the HTTP signature must be either
             1) the private key paired with a verification method that matches
             the controller of the root zcap or 2) a verification method that is
             controlled by the controller of the root zcap &mdash; and authorized for the
@@ -1639,6 +1638,12 @@ Signature: zcap=:m28+dfHk1Pq6VvKxFxX9Q9zNz98bX5cKldP1M0zNzM3NzUzNzdXNzr1PzM3NzUz
               <h4>v0.5.0</h4>
               <p>
                   This milestone is not yet planned. Once <a href="#milestone-v0.4.0">v0.4</a> is done, it will be planned from issues in the <a href="#backlog">backlog</a> and issue tracker.
+              </p>
+              <p>
+                  Unlike <a href="#milestone-v0.4.0">v0.4.0</a>, which is limited to non-normative changes,
+                  this milestone may include normative changes.
+                  Normative changes made so far are recorded in the
+                  <a href="#changelog-v0.5.0">Change Log</a>.
               </p>
           </section>
       </section>


### PR DESCRIPTION
Note: the target branch for this is v0.5.0-draft, since this contains a normative change, and the main branch is still on v0.4.x.

Motivation:
* resolve https://github.com/w3c-ccg/zcap-spec/issues/109
